### PR TITLE
feat: Add input audio buffer event handling

### DIFF
--- a/src/agents/voice/models/sdk_realtime.py
+++ b/src/agents/voice/models/sdk_realtime.py
@@ -26,6 +26,10 @@ from ..realtime.model import (
     RealtimeEventRateLimitsUpdated,
     RealtimeEventInputAudioTranscriptionDelta,
     RealtimeEventInputAudioTranscriptionCompleted,
+    RealtimeEventInputAudioBuffer,
+    RealtimeEventInputAudioBufferSpeechStarted,
+    RealtimeEventInputAudioBufferSpeechStopped,
+    RealtimeEventInputAudioBufferCommitted,
 )
 from ...exceptions import AgentsException, UserError
 from ...logger import logger
@@ -281,10 +285,28 @@ class SDKRealtimeSession(RealtimeSession):
                         )
 
                     # Log other VAD-related and lifecycle events without putting them on main queue for now
+                    elif event.type == "input_audio_buffer.speech_started":
+                        await self._event_queue.put(
+                            RealtimeEventInputAudioBufferSpeechStarted(
+                                timestamp=event.timestamp,
+                                event_id=event.event_id
+                            )
+                        )
+                    elif event.type == "input_audio_buffer.speech_stopped":
+                        await self._event_queue.put(
+                            RealtimeEventInputAudioBufferSpeechStopped(
+                                timestamp=event.timestamp,
+                                event_id=event.event_id
+                            )
+                        )
+                    elif event.type == "input_audio_buffer.committed":
+                        await self._event_queue.put(
+                            RealtimeEventInputAudioBufferCommitted(
+                                timestamp=event.timestamp,
+                                event_id=event.event_id
+                            )
+                        )
                     elif event.type in [
-                        "input_audio_buffer.speech_started",
-                        "input_audio_buffer.speech_stopped",
-                        "input_audio_buffer.committed",
                         "conversation.item.created",
                         "response.created",
                         "response.output_item.added",  # Might be useful if we track item lifecycles

--- a/src/agents/voice/realtime/model.py
+++ b/src/agents/voice/realtime/model.py
@@ -81,6 +81,30 @@ class RealtimeEventInputAudioTranscriptionCompleted:
     )
 
 
+@dataclass
+class RealtimeEventInputAudioBufferSpeechStarted:
+    """Event indicating speech has started in the input audio buffer."""
+    timestamp: float  # Unix timestamp in seconds
+    event_id: str  # Unique identifier for the event
+    type: Literal["input_audio_buffer_speech_started"] = "input_audio_buffer_speech_started"
+
+
+@dataclass
+class RealtimeEventInputAudioBufferSpeechStopped:
+    """Event indicating speech has stopped in the input audio buffer."""
+    timestamp: float  # Unix timestamp in seconds
+    event_id: str  # Unique identifier for the event
+    type: Literal["input_audio_buffer_speech_stopped"] = "input_audio_buffer_speech_stopped"
+
+
+@dataclass
+class RealtimeEventInputAudioBufferCommitted:
+    """Event indicating the input audio buffer has been committed."""
+    timestamp: float  # Unix timestamp in seconds
+    event_id: str  # Unique identifier for the event
+    type: Literal["input_audio_buffer_committed"] = "input_audio_buffer_committed"
+
+
 RealtimeEvent = (
     RealtimeEventSessionBegins
     | RealtimeEventAudioChunk
@@ -92,6 +116,9 @@ RealtimeEvent = (
     | RealtimeEventRateLimitsUpdated
     | RealtimeEventInputAudioTranscriptionDelta
     | RealtimeEventInputAudioTranscriptionCompleted
+    | RealtimeEventInputAudioBufferSpeechStarted
+    | RealtimeEventInputAudioBufferSpeechStopped
+    | RealtimeEventInputAudioBufferCommitted
 )
 
 

--- a/src/agents/voice/result_realtime.py
+++ b/src/agents/voice/result_realtime.py
@@ -14,6 +14,17 @@ from .events import (
     VoiceStreamEventLifecycle,
     VoiceStreamEventToolCall,
 )
+from .realtime.model import (
+    RealtimeEventAudioChunk,
+    RealtimeEventError as LLMErrorEvent,
+    RealtimeEventSessionBegins,
+    RealtimeEventSessionEnds,
+    RealtimeEventTextDelta,
+    RealtimeEventToolCall as LLMToolCallEvent,
+    RealtimeEventInputAudioBufferSpeechStarted,
+    RealtimeEventInputAudioBufferSpeechStopped,
+    RealtimeEventInputAudioBufferCommitted,
+)
 from .pipeline_config import (
     VoicePipelineConfig,
 )  # Assuming this might be needed for settings
@@ -116,6 +127,12 @@ class StreamedRealtimeResult:
                     )
                 )
                 await self._done()  # Mark as done on error
+
+            # Handle input audio buffer events
+            elif isinstance(llm_event, (RealtimeEventInputAudioBufferSpeechStarted,
+                                      RealtimeEventInputAudioBufferSpeechStopped,
+                                      RealtimeEventInputAudioBufferCommitted)):
+                await self._event_queue.put(llm_event)
 
             # Other RealtimeEvent types like SessionStatus could be handled here if needed.
 


### PR DESCRIPTION
This pull request introduces new event types for handling input audio buffer events in the real-time voice processing system. These changes enhance the system's ability to process and respond to events related to speech detection and buffer management. Below is a summary of the most significant changes:

### New Event Types and Models:
* Added new dataclasses: `RealtimeEventInputAudioBufferSpeechStarted`, `RealtimeEventInputAudioBufferSpeechStopped`, and `RealtimeEventInputAudioBufferCommitted` in `src/agents/voice/realtime/model.py`. These classes define the structure for events related to speech detection and buffer commitment, including attributes like timestamp, event ID, and event type. [[1]](diffhunk://#diff-d173053d067cb65c10423004bb930269c106405da8582c8544e0762678632d04R84-R107) [[2]](diffhunk://#diff-d173053d067cb65c10423004bb930269c106405da8582c8544e0762678632d04R119-R121)

### Event Handling in Real-Time Processing:
* Updated `_receiver_loop` in `src/agents/voice/models/sdk_realtime.py` to handle the new input audio buffer events (`speech_started`, `speech_stopped`, and `committed`) by adding them to the event queue. Removed these events from being ignored in the previous implementation.

### Integration with Result Processing:
* Modified `_add_realtime_llm_event` in `src/agents/voice/result_realtime.py` to process the new input audio buffer events by adding them to the event queue, ensuring they are handled appropriately in the result lifecycle.

### Import Updates:
* Added imports for the new event types in `src/agents/voice/models/sdk_realtime.py` and `src/agents/voice/result_realtime.py` to integrate them into the respective modules. [[1]](diffhunk://#diff-63d049cfdc1a2e41df1067b2d37719897806f9be60ea7e3db0e455fab1da6096R29-R32) [[2]](diffhunk://#diff-c088369a9bbfd7518407fec493b200b86cb824f92acf19fe767d6933d2caa9ceR17-R27)

[OpenAI API Reference](https://platform.openai.com/docs/api-reference/realtime-server-events/input_audio_buffer/committed#realtime-server-events/input_audio_buffer)